### PR TITLE
Re-organize Cro::Iri code to pass more tests

### DIFF
--- a/t/iri.t
+++ b/t/iri.t
@@ -13,7 +13,7 @@ sub parses($desc, $uri, *@checks, :$relative, :$ref) {
         }
     }
     else {
-        diag "URI parsing failed: $!";
+        diag "IRI parsing failed: $!";
         flunk $desc;
         skip 'Failed to parse', @checks.elems;
     }


### PR DESCRIPTION
Prior to this the copy-pasted ref and relative-ref rules did nothing
while the class itself has missed some other important rules and
action methods to actually pass the URI tests
("By definition, every URI is an IRI").

This also adds the usual `Cro::Uri` methods `parse-relative` and `parse-ref`
to `Cro::Iri` as well.