### PR TITLE
Fix parsing media types with '.' in them

### DIFF
--- a/lib/Cro/MediaType.pm6
+++ b/lib/Cro/MediaType.pm6
@@ -49,7 +49,7 @@ class Cro::MediaType {
         }
         token qtext { <-["\\\n]>+ }
         token quoted-pair { \\ <( . )> }
-        token token { <[A..Za..z0..9!#$%&'*+^_`{|}~-]>+ }
+        token token { <[A..Za..z0..9!#$%&'*+^_`{|}~\.-]>+ }
     }
 
     class Actions {

--- a/t/mediatype.t
+++ b/t/mediatype.t
@@ -72,6 +72,16 @@ parses 'text/plain; charset=UTF-8;', 'Media type with stray ; after parameter', 
     is .Str, 'text/plain; charset=UTF-8', 'Stringifies correctly';
 };
 
+parses 'application/json; charset=utf-8; api-version=7.1-preview.1', 'Media type with . in parameter', {
+    is .type, 'application', 'Correct type';
+    is .subtype, 'json', 'Correct subtype';
+    is .subtype-name, 'json', 'Correct subtype name';
+    is .tree, '', 'No tree';
+    is .suffix, '', 'No suffix';
+    is-deeply .parameters.List, ('charset' => 'utf-8', api-version => '7.1-preview.1'), 'Correct parameters';
+    is .Str, 'application/json; charset=utf-8; api-version=7.1-preview.1', 'Stringifies correctly';
+};
+
 parses 'text/plain;', 'Media type with stray ; at end, but no parameters', {
     is .type, 'text', 'Correct type';
     is .subtype, 'plain', 'Correct subtype';


### PR DESCRIPTION
Related to https://github.com/croservices/cro-core/issues/7 and https://github.com/croservices/cro-core/issues/34

According to [RFC 2045][1]:

    value := token / quoted-string
    token := 1*<any (US-ASCII) CHAR except SPACE, CTLs,
                or tspecials>
    tspecials :=  "(" / ")" / "<" / ">" / "@" /
                  "," / ";" / ":" / "\" / <">
                  "/" / "[" / "]" / "?" / "="
                  ; Must be in quoted-string,
                  ; to use within parameter values

The RFC provides a good-list, while the code gives a bad-list. I didn't go
through the ASCII charset to check whether the two match up. I did notice
that '.' is missing though, because the azure.com API returns dots in
parameters.
[RFC 6838][2] Allows the '.' as a char in parameter values just as well.

[1]: https://www.ietf.org/rfc/rfc2045.txt
[2]: https://datatracker.ietf.org/doc/html/rfc6838#section-4.2