### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           - macOS-latest
           - windows-latest
         raku-version:
-          - "2021.03"
+          - "2021.07"
           - "latest"
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Github moved the macos-latest runner to ARM M1. There are no precompiled rakudo binaries available for that release though. Bump to 2021.07. That's the first release with MacOS ARM binaries on offer.